### PR TITLE
Fix: Access to the path is denied

### DIFF
--- a/FNLRemapper/Main.cs
+++ b/FNLRemapper/Main.cs
@@ -45,7 +45,7 @@ namespace FNLRemapper
             BeginInvoke(new MethodInvoker(async () =>
             {
                 FontReader?.Dispose();
-                FontReader = File.Open(FontPath, FileMode.Open);
+                FontReader = File.Open(FontPath, FileMode.Open, FileAccess.Read);
                 FontInfo = await FNA.Open(FontReader, null);
 
                 pnFontMenu.Visible = true;


### PR DESCRIPTION
The source code does not explicitly set value for `FileAccess access` parameter when calling `File.Open`.  Without proper configuration, _Access to the path is denied_ error occurs.

![unknown1](https://user-images.githubusercontent.com/23451424/141307909-93e8f397-36b8-4511-a50b-eee4554e0e16.png)

This commit simply fix it by adding that missing parameter.